### PR TITLE
Fix "File not found" exception for packages with mono

### DIFF
--- a/solved/chapter-1.fsx
+++ b/solved/chapter-1.fsx
@@ -51,7 +51,7 @@ The data is in CSV format. We will use the CSV type
 provider from fsharp.data to access the data.
 *)
 
-#r "../packages/fsharp.data/lib/net40/fsharp.data.dll"
+#r "../packages/FSharp.Data/lib/net40/FSharp.Data.dll"
 open FSharp.Data
 
 [<Literal>]
@@ -154,9 +154,10 @@ the XPlot library, a wrapper over Google Charts, to
 visualize our wine dataset.
 *)
 
-#r "../packages/newtonsoft.json/lib/net45/newtonsoft.json.dll"
-#r "../packages/xplot.googlecharts/lib/net45/xplot.googlecharts.dll"
-#r "../packages/google.datatable.net.wrapper/lib/google.datatable.net.wrapper.dll"
+#I "../packages/Newtonsoft.Json/lib/net45/"
+#I "../packages/Google.DataTable.Net.Wrapper/lib/"
+#r "../packages/XPlot.GoogleCharts/lib/net45/XPlot.GoogleCharts.dll"
+
 open XPlot.GoogleCharts
 
 [ (1.0,5.0); (2.0,7.0); (3.0,3.0); (4.0,10.0) ] 

--- a/solved/chapter-2.fsx
+++ b/solved/chapter-2.fsx
@@ -14,12 +14,13 @@ What we have so far
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 *)
 
-#r "../packages/fsharp.data/lib/net40/fsharp.data.dll"
+#r "../packages/FSharp.Data/lib/net40/FSharp.Data.dll"
 open FSharp.Data
 
-#r "../packages/newtonsoft.json/lib/net45/newtonsoft.json.dll"
-#r "../packages/xplot.googlecharts/lib/net45/xplot.googlecharts.dll"
-#r "../packages/google.datatable.net.wrapper/lib/google.datatable.net.wrapper.dll"
+#I "../packages/Newtonsoft.Json/lib/net45/"
+#I "../packages/Google.DataTable.Net.Wrapper/lib/"
+#r "../packages/XPlot.GoogleCharts/lib/net45/XPlot.GoogleCharts.dll"
+
 open XPlot.GoogleCharts
 
 [<Literal>]

--- a/solved/chapter-3.fsx
+++ b/solved/chapter-3.fsx
@@ -19,13 +19,13 @@ What we have so far
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 *)
 
-#I "../packages/"
-#r "fsharp.data/lib/net40/fsharp.data.dll"
+#r "../packages/FSharp.Data/lib/net40/FSharp.Data.dll"
 open FSharp.Data
 
-#r "newtonsoft.json/lib/net45/newtonsoft.json.dll"
-#r "xplot.googlecharts/lib/net45/xplot.googlecharts.dll"
-#r "google.datatable.net.wrapper/lib/google.datatable.net.wrapper.dll"
+#I "../packages/Newtonsoft.Json/lib/net45/"
+#I "../packages/Google.DataTable.Net.Wrapper/lib/"
+#r "../packages/XPlot.GoogleCharts/lib/net45/XPlot.GoogleCharts.dll"
+
 open XPlot.GoogleCharts
 
 [<Literal>]

--- a/workshop/chapter-1.fsx
+++ b/workshop/chapter-1.fsx
@@ -50,7 +50,7 @@ The data is in CSV format. We will use the CSV type
 provider from fsharp.data to access the data.
 *)
 
-#r "../packages/fsharp.data/lib/net40/fsharp.data.dll"
+#r "../packages/FSharp.Data/lib/net40/FSharp.Data.dll"
 open FSharp.Data
 
 [<Literal>]
@@ -147,9 +147,10 @@ the XPlot library, a wrapper over Google Charts, to
 visualize our wine dataset.
 *)
 
-#r "../packages/newtonsoft.json/lib/net45/newtonsoft.json.dll"
-#r "../packages/xplot.googlecharts/lib/net45/xplot.googlecharts.dll"
-#r "../packages/google.datatable.net.wrapper/lib/google.datatable.net.wrapper.dll"
+#I "../packages/Newtonsoft.Json/lib/net45/"
+#I "../packages/Google.DataTable.Net.Wrapper/lib/"
+#r "../packages/XPlot.GoogleCharts/lib/net45/XPlot.GoogleCharts.dll"
+
 open XPlot.GoogleCharts
 
 [ (1.0,5.0); (2.0,7.0); (3.0,3.0); (4.0,10.0) ] 

--- a/workshop/chapter-2.fsx
+++ b/workshop/chapter-2.fsx
@@ -14,12 +14,13 @@ What we have so far
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 *)
 
-#r "../packages/fsharp.data/lib/net40/fsharp.data.dll"
+#r "../packages/FSharp.Data/lib/net40/FSharp.Data.dll"
 open FSharp.Data
 
-#r "../packages/newtonsoft.json/lib/net45/newtonsoft.json.dll"
-#r "../packages/xplot.googlecharts/lib/net45/xplot.googlecharts.dll"
-#r "../packages/google.datatable.net.wrapper/lib/google.datatable.net.wrapper.dll"
+#I "../packages/Newtonsoft.Json/lib/net45/"
+#I "../packages/Google.DataTable.Net.Wrapper/lib/"
+#r "../packages/XPlot.GoogleCharts/lib/net45/XPlot.GoogleCharts.dll"
+
 open XPlot.GoogleCharts
 
 [<Literal>]

--- a/workshop/chapter-3.fsx
+++ b/workshop/chapter-3.fsx
@@ -19,13 +19,13 @@ What we have so far
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 *)
 
-#I "../packages/"
-#r "fsharp.data/lib/net40/fsharp.data.dll"
+#r "../packages/FSharp.Data/lib/net40/FSharp.Data.dll"
 open FSharp.Data
 
-#r "newtonsoft.json/lib/net45/newtonsoft.json.dll"
-#r "xplot.googlecharts/lib/net45/xplot.googlecharts.dll"
-#r "google.datatable.net.wrapper/lib/google.datatable.net.wrapper.dll"
+#I "../packages/Newtonsoft.Json/lib/net45/"
+#I "../packages/Google.DataTable.Net.Wrapper/lib/"
+#r "../packages/XPlot.GoogleCharts/lib/net45/XPlot.GoogleCharts.dll"
+
 open XPlot.GoogleCharts
 
 [<Literal>]


### PR DESCRIPTION
Now it works on linux and windows the same way.
